### PR TITLE
`#include <cmath>` first, to avoid `#define _USE_MATH_DEFINES` being …

### DIFF
--- a/hdr_sampling.cpp
+++ b/hdr_sampling.cpp
@@ -25,18 +25,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <vulkan/vulkan.hpp>
-
 #define _USE_MATH_DEFINES
 #include <cmath>
+#include <numeric>
+#include <vulkan/vulkan.hpp>
 
 #include "fileformats/stb_image.h"
 #include "hdr_sampling.hpp"
 #include "nvh/fileoperations.hpp"
 #include "nvvk/commands_vk.hpp"
 #include "nvvk/debug_util_vk.hpp"
-#include <numeric>
-
 
 /*
  * HDR sampling is loading an HDR image and creating an acceleration structure for 


### PR DESCRIPTION
…ignored

It seems that in some cases, if `#include <vulkan/vulkan.hpp>` comes first,
`#define _USE_MATH_DEFINES` will be ignored, because (presumably) `<cmath>`
was already included without `_USE_MATH_DEFINES` defined.

Signed-off-by: Layla <layla@insightfulvr.com>

------------------------------------------

Update: I've narrowed this down more carefully:

`accelstruct.cpp` being included via alphabetical-ordered `Unity Build` before `hdr_sampling.cpp` in my build system is what brings `<cmath>` in before we get to `#define _USE_MATH_DEFINES` here. `accelstruct.cpp` eventually through the chain includes `fileformats\tiny_gltf.h` which includes vanilla `<cmath>`. So the real fix is to ensure that `hdrsampling.cpp` gets built first in the `Unity` (though the real-real fix could also be defining `_USE_MATH_DEFINES` at the compiler level, which is what I'm going to do in my build system).

This re-ordering of includes may still be worth merging for the reason that we don't want anyone else `#include`ing `<cmath>` before we do...